### PR TITLE
Update Tweak.xm

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,16 +1,14 @@
 %hook SPTFreeTierPlaylistTrackShuffler
 - (void)setRandomNumbers:(id)arg1 {
-return %orig;
+    %orig;
 } 
 
 - (id)randomNumbers {
-return %orig;
+    return %orig;
 } 
 
 - (double)weightForTrack:(id)arg1 recommendedTrack:(bool)arg2 mergedList:(bool)arg3 {
-    arg2 = NO;
-    arg3 = NO;
-    return %orig;
+    return %orig(arg1, NO, NO);
 } 
 %end
 
@@ -22,12 +20,11 @@ return %orig;
 
 %hook SPTNowPlayingShuffleButton
 - (id)iconColor {
-    return [UIColor colorWithRed:134.0/255.0 green:198.0/255.0 blue:255.0/255.0 alpha:255.0/255.0];
+    return [UIColor colorWithRed:134.0/255.0 green:198.0/255.0 blue:1.0 alpha:1.0];
 } 
 
 - (void)setIconColor:(id)arg1 {
-    arg1 = [UIColor colorWithRed:134.0/255.0 green:198.0/255.0 blue:255.0/255.0 alpha:255.0/255.0];
-    %orig;
+    %orig([UIColor colorWithRed:134.0/255.0 green:198.0/255.0 blue:1.0 alpha:1.0]);
 } 
 %end
 


### PR DESCRIPTION
fixed return in void
used %orig() rather than setting the arguments then calling %orig
return %orig with color argument rather than setting arg1 and calling %orig

(also I'm pretty sure randomNumber and setRandomNumber don't need to be hooked since its just calling the original function)